### PR TITLE
feat: reset trainee onboarding from admin שאלונים tab

### DIFF
--- a/frontend/src/components/UserDashboard/FormResponses/UserFormResponses.tsx
+++ b/frontend/src/components/UserDashboard/FormResponses/UserFormResponses.tsx
@@ -1,16 +1,50 @@
+import { useState } from "react";
 import { useParams } from "react-router-dom";
+import { FaRotateLeft } from "react-icons/fa6";
+
+import ConfirmationDialog from "@/components/Alerts/ConfirmationDialog";
 import FormResponsesTable from "@/components/tables/FormResponsesTable";
+import useResetOnboarding from "@/hooks/mutations/User/useResetOnboarding";
 
 const UserFormResponses = () => {
   const { id } = useParams();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const resetOnboarding = useResetOnboarding();
 
   if (!id) {
     return null;
   }
 
+  const handleConfirm = () => {
+    resetOnboarding.mutate(id);
+  };
+
   return (
     <div className="p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-base font-bold text-slate-900 dark:text-slate-100">שאלונים</h3>
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          disabled={resetOnboarding.isPending}
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+        >
+          <FaRotateLeft size={11} />
+          {resetOnboarding.isPending ? "מאפס…" : "שלח שאלון מהתחלה"}
+        </button>
+      </div>
+
       <FormResponsesTable userId={id} />
+
+      <ConfirmationDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={handleConfirm}
+        title="שלח שאלון מהתחלה?"
+        description="המתאמן יופנה מחדש לשאלון ההיכרות בפתיחה הבאה של האפליקציה. השאלונים הקיימים יישארו בהיסטוריה כאן."
+        confirmLabel="שלח שאלון"
+        cancelLabel="ביטול"
+      />
     </div>
   );
 };

--- a/frontend/src/hooks/mutations/User/useResetOnboarding.ts
+++ b/frontend/src/hooks/mutations/User/useResetOnboarding.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { ERROR_MESSAGES } from "@/enums/ErrorMessages";
+import { QueryKeys } from "@/enums/QueryKeys";
+import { useUsersApi } from "@/hooks/api/useUsersApi";
+
+const useResetOnboarding = () => {
+  const { updateUserField } = useUsersApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) => updateUserField(userId, "onboardingStep", "form"),
+    onSuccess: (_data, userId) => {
+      toast.success("המתאמן חזר למסך השאלון הראשוני");
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.USERS, userId] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.USERS] });
+    },
+    onError: (e: any) => {
+      toast.error(ERROR_MESSAGES.GENERIC_ERROR_MESSAGE, {
+        description: e?.data?.message || "",
+      });
+    },
+  });
+};
+
+export default useResetOnboarding;


### PR DESCRIPTION
Adds a "שלח שאלון מהתחלה" button on the trainee dashboard's שאלונים tab that sets the user's onboardingStep field back to "form". The mobile client's RootNavigator watches this field and bounces the trainee back to the intake form on the next me-refetch, so no additional server or mobile changes are needed.

- New mutation: useResetOnboarding — thin wrapper over useUsersApi.updateUserField(userId, "onboardingStep", "form") with USERS query invalidation and Hebrew success toast.
- UserFormResponses.tsx: header row with reset button + destructive ConfirmationDialog. Existing FormResponse records are preserved (visible as history in the same tab).